### PR TITLE
to avoid problems with subtitle with a chatset different than utf-8

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -38,6 +38,7 @@ ep.prototype.get = function(action, params, cb) {
 	var req = http.request(this.options);
 	req.on('response', function (response) {
 
+        //to avoid problems with subtitle with a chatset different than utf-8
         response.setEncoding('binary');
 
 		response.on('data', function (chunk) {


### PR DESCRIPTION
Some subtitles has a charset different than utf-8, so i had to encode response to binary to avoid this problem.
